### PR TITLE
Few addition of Python>3.8 for new codeGen compatibility

### DIFF
--- a/CompileC.sh
+++ b/CompileC.sh
@@ -73,6 +73,7 @@ then
     module load load-epcc-module
     module load cmake/3.21.3
     module load PrgEnv-gnu
+    module load cray-python/3.9.13.1
 
     if [ -z ${HDF5Root} ]
     then
@@ -87,8 +88,9 @@ then
     then
         module load hdf5/1.10.2/gcc/parallel
     fi
-    module load cuda/10.0
+    #module load cuda/10.0
     module load cmake
+    module load python/3.9.7
 fi
 
 OpenSBLIBuild="BUILD_OPS_C_SAMPLE(OpenSBLI \"NONE\" \"NONE\" \"NONE\" \"NO\" \"NO\")"

--- a/CompileC.sh
+++ b/CompileC.sh
@@ -98,6 +98,7 @@ OpenSBLIBuild="BUILD_OPS_C_SAMPLE(OpenSBLI \"NONE\" \"NONE\" \"NONE\" \"NO\" \"N
 cp $EnvDir/CMakeLists.txt .
 sed -i '/add_subdirectory/d' CMakeLists.txt
 sed -i "\$a${OpenSBLIBuild}" CMakeLists.txt
+rm -rf build
 mkdir build
 cd build
 cmake ../ -DOPS_INSTALL_DIR=$EnvDir/OPS-INSTALL -DCMAKE_BUILD_TYPE=Release -DOPS_TEST=OFF ${OPTIMISATION} -DAPP_INSTALL_DIR=$HOME/OPS-APP -DGPU_NUMBER=1 ${HDF5Root}

--- a/CompileC.sh
+++ b/CompileC.sh
@@ -88,7 +88,7 @@ then
     then
         module load hdf5/1.10.2/gcc/parallel
     fi
-    #module load cuda/10.0
+    module load cuda/10.0
     module load cmake
     module load python/3.9.7
 fi

--- a/CreateOpenSBLIEnv.sh
+++ b/CreateOpenSBLIEnv.sh
@@ -101,8 +101,8 @@ cd $Dir ## needed by normal version
 wget -c https://github.com/opensbli/environment_and_run_scripts/archive/refs/heads/main.zip
 unzip main.zip
 rm main.zip
-mv aosh-main/*  .
-rm -r -f aosh-main
+mv environment_and_run_scripts-main/*  .
+rm -r -f environment_and_run_scripts-main
 # Set the default machine in CompileC.sh changed from "Ubuntu" to "None"
 sed -i "s/Machine=\"None\"/Machine=\"${Machine}\"/g" CompileC.sh
 ## Install local HDF5 if needed

--- a/InstallOPS.sh
+++ b/InstallOPS.sh
@@ -109,6 +109,7 @@ then
     module load load-epcc-module
     module load cmake/3.21.3
     module load PrgEnv-gnu
+    module load cray-python/3.9.13.1
 
     if [ -z ${HDF5Root} ]
     then
@@ -125,6 +126,7 @@ then
     fi
     module load cuda/10.0
     module load cmake
+    module load python/3.9.7
 fi
 
 #https://github.com/OP-DSL/OPS/archive/refs/heads/feature/HDF5Slice.zip

--- a/InstallOPS.sh
+++ b/InstallOPS.sh
@@ -124,7 +124,7 @@ then
     then
         module load hdf5/1.10.2/gcc/parallel
     fi
-    module load cuda/10.0
+    #module load cuda/10.0
     module load cmake
     module load python/3.9.7
 fi

--- a/InstallOPS.sh
+++ b/InstallOPS.sh
@@ -124,7 +124,7 @@ then
     then
         module load hdf5/1.10.2/gcc/parallel
     fi
-    #module load cuda/10.0
+    module load cuda/10.0
     module load cmake
     module load python/3.9.7
 fi


### PR DESCRIPTION
New modules are added to make the script installation compatible with the latest codegen which requires Python 3.8 and above.